### PR TITLE
fix systemtcl unit file refresh

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: systemctl daemon-reload
+  systemd:
+    daemon_reload: true
+
 - name: restart keepalived
   service:
     name: "{{ keepalived_service_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -226,6 +226,8 @@
   when:
     - ansible_service_mgr == 'systemd'
     - keepalived_systemd_overrides | bool
+  notify:
+    - systemctl daemon-reload
 
 - name: Apply keepalived override to restart service allways
   ini_file:
@@ -237,6 +239,8 @@
     - ansible_service_mgr == 'systemd'
     - keepalived_systemd_overrides | bool
     - keepalived_systemd_override_service_restart | bool
+  notify:
+    - systemctl daemon-reload
 
 - name: Remove keepalived overrides
   file:
@@ -245,3 +249,5 @@
   when:
     - ansible_service_mgr == 'systemd'
     - not (keepalived_systemd_overrides | bool)
+  notify:
+    - systemctl daemon-reload


### PR DESCRIPTION
Systemd unit files are modified and the daemon needs to be reloaded so that it can pick them up. In order for this to be restarted before the keepalived service, this needs to be the first task in the handlers file.

Current issue with the role will give you the following warning as the unit files have not been refreshed.

```
$ systemctl status keepalived
Warning: The unit file, source configuration file or drop-ins of keepalived.service changed on disk. Run 'systemctl daemon-reload' to reload units.
```